### PR TITLE
RMPMP-242: Updated `WithDeadLetterTopic` option to borrow username and password from ConsumerTopicConfig when those issues aren't specified on DeadLetterTopicConfig

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to Semantic Versioning.
 
+## 1.0.1 (Sep 3, 2024)
+
+1. Added dlt topic name in error logs on dlt write failure
+
 ## 1.0.0 (July 2024)
 
 Initial release to public github.com

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to Semantic Versioning.
 
+## 1.0.2 (Sep 6, 2024)
+
+1. Updated `WithDeadLetterTopic` option to borrow username and password from ConsumerTopicConfig when those issues aren't specified on DeadLetterTopicConfig
+
 ## 1.0.1 (Sep 3, 2024)
 
 1. Added dlt topic name in error logs on dlt write failure

--- a/workoption.go
+++ b/workoption.go
@@ -119,7 +119,7 @@ func (d dltOption) apply(w *Work) {
 		// establish a writer to the DLT early, so when the time comes the write is fast
 		writer, err := w.kafkaProvider.Writer(ctx, d.dltConfig)
 		if err != nil {
-			w.logger.Errorw(ctx, "Failed to get writer for dlt", "error", err, "offset", message.Offset, "partition", message.Partition, "topic", message.Topic)
+			w.logger.Errorw(ctx, "Failed to get writer for dlt", "error", err, "offset", message.Offset, "partition", message.Partition, "source_topic", message.Topic, "dlt_topic", d.dltConfig.Topic)
 			return
 		}
 
@@ -136,7 +136,7 @@ func (d dltOption) apply(w *Work) {
 		}
 
 		if _, err := writer.WriteRaw(ctx, &message.Key, message.value); err != nil {
-			w.logger.Errorw(ctx, "Failed to forward to DLT", "error", err, "offset", message.Offset, "partition", message.Partition, "topic", message.Topic)
+			w.logger.Errorw(ctx, "Failed to forward to DLT", "error", err, "offset", message.Offset, "partition", message.Partition, "source_topic", message.Topic, "dlt_topic", d.dltConfig.Topic)
 		}
 	}
 	w.onDones = append(w.onDones, f)

--- a/workoption.go
+++ b/workoption.go
@@ -115,9 +115,18 @@ func (d dltOption) apply(w *Work) {
 			return
 		}
 
+		// if not specified explicitly in dlt config, use username/pw from consumerTopicConfig
+		dltConfig := d.dltConfig
+		if dltConfig.SaslUsername == nil || *d.dltConfig.SaslUsername == "" {
+			dltConfig.SaslUsername = w.topicConfig.SaslUsername
+		}
+
+		if dltConfig.SaslPassword == nil || *d.dltConfig.SaslPassword == "" {
+			dltConfig.SaslPassword = w.topicConfig.SaslPassword
+		}
 		// even if we're going to skip forwarding a message to the DLT (because there was no error),
 		// establish a writer to the DLT early, so when the time comes the write is fast
-		writer, err := w.kafkaProvider.Writer(ctx, d.dltConfig)
+		writer, err := w.kafkaProvider.Writer(ctx, dltConfig)
 		if err != nil {
 			w.logger.Errorw(ctx, "Failed to get writer for dlt", "error", err, "offset", message.Offset, "partition", message.Partition, "source_topic", message.Topic, "dlt_topic", d.dltConfig.Topic)
 			return


### PR DESCRIPTION
RMPMP-242: Updated `WithDeadLetterTopic` option to borrow username and password from ConsumerTopicConfig when those issues aren't specified on DeadLetterTopicConfig