### PR TITLE
Added `WithDisableCircuitBreaker` and `WithDisableBusyLoopBreaker` options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to Semantic Versioning.
 
+## 1.3.0 (Sep 25, 2024)
+
+1. Added `WithDisableCircuitBreaker` and `WithDisableBusyLoopBreaker` options. These are variants of the now deprecated `DisableCircuitBreaker`
+and `DisableBusyLoopBreaker` options. They provide a booling parameter which is more convenient for usage with
+code generation and for shimming with configuration.
+
 ## 1.2.0 (Sep 23, 2024)
 
 1. Update to allow subject name specification (not just TopicNameStrategy)

--- a/work.go
+++ b/work.go
@@ -83,7 +83,7 @@ type Work struct {
 	// Duration for which a circuit is open. Use CircuitBreakFor to control
 	cbFor *time.Duration
 
-	// Disable circuit breaking. Use DisableCircuitBreaker to control
+	// Disable circuit breaking. Use WithDisableCircuitBreaker to control
 	disableCb bool
 
 	// Busy loop breaker. When circuit breaker circuit is open, instead of consuming cpu in a busy loop

--- a/workoption.go
+++ b/workoption.go
@@ -26,15 +26,26 @@ func CircuitBreakFor(duration time.Duration) WorkOption {
 	return circuitBreakForOption{duration: duration}
 }
 
-// DisableCircuitBreaker disables the circuit breaker so that it never breaks
+// Deprecated: DisableCircuitBreaker disables the circuit breaker so that it never breaks
 func DisableCircuitBreaker() WorkOption {
-	return disableCbOption{}
+	return WithDisableCircuitBreaker(true)
 }
 
-// DisableBusyLoopBreaker disables the busy loop breaker which would block subsequent read calls till the circuit re-closes.
+// WithDisableCircuitBreaker allows the user to control whether circuit breaker is disabled or not
+func WithDisableCircuitBreaker(isDisabled bool) WorkOption {
+	return disableCbOption{disabled: isDisabled}
+}
+
+// Deprecated: DisableBusyLoopBreaker disables the busy loop breaker which would block subsequent read calls till the circuit re-closes.
 // Without blb we see increased cpu usage when circuit is open
 func DisableBusyLoopBreaker() WorkOption {
-	return disableBlbOption{}
+	return WithDisableBusyLoopBreaker(true)
+}
+
+// WithDisableBusyLoopBreaker disables the busy loop breaker which would block subsequent read calls till the circuit re-closes.
+// Without blb we see increased cpu usage when circuit is open
+func WithDisableBusyLoopBreaker(isDisabled bool) WorkOption {
+	return disableBlbOption{disabled: isDisabled}
 }
 
 // WithOnDone allows you to specify a callback function executed after processing of a kafka message
@@ -75,7 +86,9 @@ func (c circuitBreakForOption) apply(w *Work) {
 	}
 }
 
-type disableCbOption struct{}
+type disableCbOption struct {
+	disabled bool
+}
 
 func (d disableCbOption) apply(w *Work) {
 	w.disableCb = true
@@ -99,7 +112,9 @@ func (o lifeCycleOption) apply(w *Work) {
 	w.lifecycle = o.lh
 }
 
-type disableBlbOption struct{}
+type disableBlbOption struct {
+	disabled bool
+}
 
 func (d disableBlbOption) apply(w *Work) {
 	w.blb.disabled = true


### PR DESCRIPTION
Added `WithDisableCircuitBreaker` and `WithDisableBusyLoopBreaker` options. These are variants of the now deprecated `DisableCircuitBreaker`
    and `DisableBusyLoopBreaker` options. They provide a booling parameter which is more convenient for usage with
    code generation and for shimming with configuration.
