### PR TITLE
Change chained hooks nil check to correct function

### DIFF
--- a/lifecycle.go
+++ b/lifecycle.go
@@ -110,7 +110,7 @@ func ChainLifecycleHooks(hooks ...LifecycleHooks) LifecycleHooks {
 		},
 		PostReadImmediate: func(ctx context.Context, meta LifecyclePostReadImmediateMeta) {
 			for _, h := range hooks {
-				if h.PostRead != nil {
+				if h.PostReadImmediate != nil {
 					h.PostReadImmediate(ctx, meta)
 				}
 			}

--- a/lifecycle.go
+++ b/lifecycle.go
@@ -168,7 +168,7 @@ func ChainLifecycleHooks(hooks ...LifecycleHooks) LifecycleHooks {
 				Headers: make(map[string][]byte),
 			}
 			for _, h := range hooks {
-				if h.PreProcessing != nil {
+				if h.PreWrite != nil {
 					var err error
 
 					resp, err := h.PreWrite(ctx, meta)
@@ -185,7 +185,7 @@ func ChainLifecycleHooks(hooks ...LifecycleHooks) LifecycleHooks {
 		},
 		PostFanout: func(ctx context.Context) {
 			for _, h := range hooks {
-				if h.PostRead != nil {
+				if h.PostFanout != nil {
 					h.PostFanout(ctx)
 				}
 			}


### PR DESCRIPTION
The `nil` check was incorrect, resulting in a panic if the following conditions hold true:
1. You have a `PostRead` hook func defined
2. You don't have a `PostReadImmediate` hook func defined
3. You use `ChainLifecycleHooks` to use multiple hooks

`PostRead` --> `PostReadImmediate`


Additionally, a few other hook functions had what I believe are incorrect nil checks.
- `PreWrite`: Was checking if `PreProcessing` was `nil` instead of `PreWrite`
- `PostFanout`: Was check if `PostRead` was `nil` instead of `PostFanout`